### PR TITLE
Fix: Disable shellcheck SC2016

### DIFF
--- a/.github/workflows/github2gerrit.yaml
+++ b/.github/workflows/github2gerrit.yaml
@@ -261,6 +261,7 @@ jobs:
         run: |
           set -x
 
+          # shellcheck disable=SC2016
           gh api graphql --paginate \
               -F number=${{ env.PR_NUMBER }} \
               -F owner=${{ vars.ORGANIZATION }} \


### PR DESCRIPTION
gh api graphql requires single quote or would not work as expected when testing so ignore SC2016.