### PR TITLE
Fix: Re-use change-id takes precedence

### DIFF
--- a/.github/workflows/github2gerrit.yaml
+++ b/.github/workflows/github2gerrit.yaml
@@ -319,13 +319,15 @@ jobs:
               commit_message="${commit_message:-commit-msg.txt}"
           fi
 
-          # overide the change-id if the change is update on Gerrit
-          if [[ -f "reuse-cids-${{ env.PR_NUMBER }}.txt" ]] && (${{ github.event.action == 'reopened' }} || ${{ github.event.action == 'synchronize' }}); then
+          # overide and re-use the same change-id  if the change was updated
+          if [[ -s "reuse-cids-${{ env.PR_NUMBER }}.txt" ]] && (${{ github.event.action == 'reopened' }} || ${{ github.event.action == 'synchronize' }}); then
               reuse_cid="$(< "reuse-cids-${{ env.PR_NUMBER }}.txt" uniq | tail -1)"
-              echo "Change-Id: $reuse_cid" > change-Id.txt
-              commit_message+=' '
-              commit_message+="change-Id.txt"
-          elif [[ -f change-Id.txt ]]; then
+              if [ -n "${reuse_cid}" ]; then
+                  echo "Change-Id: $reuse_cid" > change-Id.txt
+                  commit_message+=' '
+                  commit_message+="change-Id.txt"
+              fi
+          elif [[ -f change-Id.txt && ! -s "reuse-cids-${{ env.PR_NUMBER }}.txt" ]]; then
               commit_message+=' '
               commit_message+="change-Id.txt"
           fi


### PR DESCRIPTION
If the change has been updated then the change-Id from the PR takes precedence. Conditional check if the change-Id has been retrived from the previous fetch step and override the change-Id provided by the commit message if that exists.

This ensure multiple changes are not created when the change is updated.