### PR TITLE
Fix: Set the Gerrit branch as GITHUB_BASE_REF

### DIFF
--- a/.github/workflows/github2gerrit.yaml
+++ b/.github/workflows/github2gerrit.yaml
@@ -163,7 +163,7 @@ jobs:
       - name: Set env GITHUB branch in env
         shell: bash
         run: |
-          gerrit_branch="${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}"
+          gerrit_branch="${GITHUB_BASE_REF:-master}"
           echo "GERRIT_BRANCH=${gerrit_branch}" >> "$GITHUB_ENV"
 
       - name: Print last X commits in the git log


### PR DESCRIPTION
The branch should be set as the target branch of the pull request, which would match with the upstream branch on Gerrit.