### PR TITLE
Chore: update pre-commit config

### DIFF
--- a/.github/workflows/github2gerrit.yaml
+++ b/.github/workflows/github2gerrit.yaml
@@ -367,19 +367,16 @@ jobs:
           fi
 
           # Dependabot workaround for LF projects enforcing an "issue-id" in commit message
-          if [ -n ${{ env.SET_ISSUE_ID }} ]; then
+          if [[ -n ${{ env.SET_ISSUE_ID }} && '${{ vars.ISSUEID }}' == 'true' ]]; then
               # workaround to remove lines with --- or ...
               sed -i -e 's#^[ ]*---##g' -e 's#^[ ]*\.\.\.##g' commit-msg.txt
-              issue_id="Issue-ID: ${{ env.SET_ISSUE_ID }}"
+              issue_id="${{ env.SET_ISSUE_ID }}"
               # shellcheck disable=SC2086
               git commit -s -v --no-edit --author "$author" -m "$(cat commit-msg.txt)" -m "$issue_id" -m "$(cat signed-off-by-final.txt)"
           else
               # shellcheck disable=SC2086
               git commit -s -v --no-edit --author "$author" -m "$(cat $commit_message)"
           fi
-
-          # # shellcheck disable=SC2086
-          # git commit -s -v --no-edit --author "$author" -m "$(cat $commit_message)"
           git log -n1
         env:
           SET_ISSUE_ID: ${{ env.SET_ISSUE_ID }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,12 +56,6 @@ repos:
     hooks:
       - id: gitlint
 
-  - repo: https://github.com/pre-commit/mirrors-prettier
-    rev: f12edd9c7be1c20cfa42420fd0e6df71e42b51ea # frozen: v4.0.0-alpha.8
-    hooks:
-      - id: prettier
-        stages: [pre-commit]
-
   - repo: https://github.com/adrienverge/yamllint.git
     rev: 81e9f98ffd059efe8aa9c1b1a42e5cce61b640c6 # frozen: v1.35.1
     hooks:


### PR DESCRIPTION
Drop prettier from the configuration as the upstream project has made
changes that make it incompatible with the pre-commit hook system.