### PR TITLE
Feat: Allow passing default value for ISSUE_ID

### DIFF
--- a/.github/workflows/github2gerrit.yaml
+++ b/.github/workflows/github2gerrit.yaml
@@ -204,6 +204,7 @@ jobs:
         with:
           json: ${{ vars.ISSUE_ID_LOOKUP_JSON }}
           key: ${{ env.key }}
+          default: ${{ vars.ISSUE_ID_DEFAULT }}
 
       - name: "Set IssueID in GITHUB_ENV"
         if: vars.ISSUEID == 'true'


### PR DESCRIPTION
This will allows us to set a default value for issue ID through a variable named ISSUE_ID_DEFAULT and avoid having an extensive username lists at ISSUE_ID_LOOKUP_JSON variable.
This has been test in my fork however there isn't an easy way to share the logs.